### PR TITLE
queryAssertion: allow whole response to be signed

### DIFF
--- a/src/OneLogin/Saml/Response.php
+++ b/src/OneLogin/Saml/Response.php
@@ -107,14 +107,14 @@ class OneLogin_Saml_Response
         $xpath->registerNamespace('saml'    , 'urn:oasis:names:tc:SAML:2.0:assertion');
         $xpath->registerNamespace('ds'      , 'http://www.w3.org/2000/09/xmldsig#');
 
-        $signatureQuery = '/samlp:Response/saml:Assertion/ds:Signature/ds:SignedInfo/ds:Reference';
+        $signatureQuery = '/samlp:Response//ds:Signature/ds:SignedInfo/ds:Reference';
         $assertionReferenceNode = $xpath->query($signatureQuery)->item(0);
         if (!$assertionReferenceNode) {
             throw new Exception('Unable to query assertion, no Signature Reference found?');
         }
         $id = substr($assertionReferenceNode->attributes->getNamedItem('URI')->nodeValue, 1);
 
-        $nameQuery = "/samlp:Response/saml:Assertion[@ID='$id']" . $assertionXpath;
+        $nameQuery = "/samlp:Response//*[@ID='$id']//saml:Assertion" . $assertionXpath;
         return $xpath->query($nameQuery);
     }
 }


### PR DESCRIPTION
Some providers sign the whole response, not just the "Assertion"
element. This change makes the xpaths to find the signature and the
assertion a little more flexible.

Note: The validity of the document is determined elsewhere, this code
mainly just tries to find the assertion that _was_ signed.
