### PR TITLE
Response: allow entire doc to be signed

### DIFF
--- a/src/OneLogin/Saml/Response.php
+++ b/src/OneLogin/Saml/Response.php
@@ -114,7 +114,7 @@ class OneLogin_Saml_Response
         }
         $id = substr($assertionReferenceNode->attributes->getNamedItem('URI')->nodeValue, 1);
 
-        $nameQuery = "/samlp:Response//*[@ID='$id']//saml:Assertion" . $assertionXpath;
+        $nameQuery = "//*[@ID='$id']//saml:Assertion" . $assertionXpath;
         return $xpath->query($nameQuery);
     }
 }


### PR DESCRIPTION
This is perhaps a bug in php's implementation of Xpath, but
"/blah//selector" is supposed to be:

if (blah.matches(selector) || blah.any_descendent_matches(selector))

But it's not working when blah.matches(selector), so getting rid of
`/blah` works.

Note: the contents of the element has already been verified, we're just
looking for the element that was signed.
