### PR TITLE
assert(): use real expressions, not strings

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -102,7 +102,7 @@ class OneLogin_Saml2_Auth
      */
     public function setStrict($value)
     {
-        assert('is_bool($value)');
+        assert(is_bool($value));
         $this->_settings->setStrict($value);
     }
 
@@ -222,8 +222,8 @@ class OneLogin_Saml2_Auth
      */
     public function redirectTo($url = '', $parameters = array(), $stay = false)
     {
-        assert('is_string($url)');
-        assert('is_array($parameters)');
+        assert(is_string($url));
+        assert(is_array($parameters));
 
         if (empty($url) && isset($_REQUEST['RelayState'])) {
             $url = $_REQUEST['RelayState'];
@@ -311,7 +311,7 @@ class OneLogin_Saml2_Auth
      */
     public function getAttribute($name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $value = null;
         if (isset($this->_attributes[$name])) {
@@ -334,7 +334,7 @@ class OneLogin_Saml2_Auth
      */
     public function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay=false, $setNameIdPolicy = true)
     {
-        assert('is_array($parameters)');
+        assert(is_array($parameters));
 
         $authnRequest = new OneLogin_Saml2_AuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy);
 
@@ -373,7 +373,7 @@ class OneLogin_Saml2_Auth
      */
     public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay=false)
     {
-        assert('is_array($parameters)');
+        assert(is_array($parameters));
 
         $sloUrl = $this->getSLOurl();
         if (empty($sloUrl)) {

--- a/lib/Saml2/Error.php
+++ b/lib/Saml2/Error.php
@@ -31,8 +31,8 @@ class OneLogin_Saml2_Error extends Exception
      */
     public function __construct($msg, $code = 0, $args = null)
     {
-        assert('is_string($msg)');
-        assert('is_int($code)');
+        assert(is_string($msg));
+        assert(is_int($code));
 
         $message = OneLogin_Saml2_Utils::t($msg, $args);
 

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -381,7 +381,7 @@ class OneLogin_Saml2_Settings
      */
     public function checkSettings($settings)
     {
-        assert('is_array($settings)');
+        assert(is_array($settings));
 
         if (!is_array($settings) || empty($settings)) {
             $errors = array('invalid_syntax');
@@ -407,7 +407,7 @@ class OneLogin_Saml2_Settings
      */
     public function checkIdPSettings($settings)
     {
-        assert('is_array($settings)');
+        assert(is_array($settings));
 
         if (!is_array($settings) || empty($settings)) {
             return array('invalid_syntax');
@@ -471,7 +471,7 @@ class OneLogin_Saml2_Settings
      */
     public function checkSPSettings($settings)
     {
-        assert('is_array($settings)');
+        assert(is_array($settings));
 
         if (!is_array($settings) || empty($settings)) {
             return array('invalid_syntax');
@@ -755,7 +755,7 @@ class OneLogin_Saml2_Settings
      */
     public function validateMetadata($xml)
     {
-        assert('is_string($xml)');
+        assert(is_string($xml));
 
         $errors = array();
         $res = OneLogin_Saml2_Utils::validateXML($xml, 'saml-schema-metadata-2.0.xsd', $this->_debug);
@@ -835,7 +835,7 @@ class OneLogin_Saml2_Settings
      */
     public function setStrict($value)
     {
-        assert('is_bool($value)');
+        assert(is_bool($value));
 
         $this->_strict = $value;
     }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -18,7 +18,7 @@ class OneLogin_Saml2_Utils
     */
     public static function t($msg, $args = array())
     {
-        assert('is_string($msg)');
+        assert(is_string($msg));
         if (extension_loaded('gettext')) {
             bindtextdomain("phptoolkit", dirname(dirname(dirname(__FILE__))).'/locale');
             textdomain('phptoolkit');
@@ -47,8 +47,8 @@ class OneLogin_Saml2_Utils
      */
     public static function loadXML($dom, $xml)
     {
-        assert('$dom instanceof DOMDocument');
-        assert('is_string($xml)');
+        assert($dom instanceof DOMDocument);
+        assert(is_string($xml));
 
         if (strpos($xml, '<!ENTITY') !== false) {
             throw new Exception('Detected use of ENTITY in XML, disabled to prevent XXE/XEE attacks');
@@ -78,8 +78,8 @@ class OneLogin_Saml2_Utils
      */
     public static function validateXML($xml, $schema, $debug = false)
     {
-        assert('is_string($xml) || $xml instanceof DOMDocument');
-        assert('is_string($schema)');
+        assert(is_string($xml) || $xml instanceof DOMDocument);
+        assert(is_string($schema));
 
         libxml_clear_errors();
         libxml_use_internal_errors(true);
@@ -217,8 +217,8 @@ class OneLogin_Saml2_Utils
      */
     public static function redirect($url, $parameters = array(), $stay = false)
     {
-        assert('is_string($url)');
-        assert('is_array($parameters)');
+        assert(is_string($url));
+        assert(is_array($parameters));
 
         if (substr($url, 0, 1) === '/') {
             $url = self::getSelfURLhost() . $url;
@@ -507,8 +507,8 @@ class OneLogin_Saml2_Utils
      */
     public static function parseDuration($duration, $timestamp = null)
     {
-        assert('is_string($duration)');
-        assert('is_null($timestamp) || is_int($timestamp)');
+        assert(is_string($duration));
+        assert(is_null($timestamp) || is_int($timestamp));
 
         /* Parse the duration. We use a very strict pattern. */
         $durationRegEx = '#^(-?)P(?:(?:(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)D)?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?)?)|(?:(\\d+)W))$#D';
@@ -672,7 +672,7 @@ class OneLogin_Saml2_Utils
      */
     public static function calculateX509Fingerprint($x509cert, $alg='sha1')
     {
-        assert('is_string($x509cert)');
+        assert(is_string($x509cert));
 
         $lines = explode("\n", $x509cert);
 
@@ -931,8 +931,8 @@ class OneLogin_Saml2_Utils
       */
     public static function castKey(XMLSecurityKey $key, $algorithm, $type = 'public')
     {
-        assert('is_string($algorithm)');
-        assert('$type === "public" || $type === "private"');
+        assert(is_string($algorithm));
+        assert($type === "public" || $type === "private");
         // do nothing if algorithm is already the type of the key
         if ($key->type === $algorithm) {
             return $key;


### PR DESCRIPTION
PHP 7.2 deprecated passing strings to assert(), it strips them out at
compile time in production instead.